### PR TITLE
Fix test command in CI

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -44,4 +44,4 @@ jobs:
     
     - name: Run tests
       timeout-minutes: 5
-      run: ${{matrix.env}} bundle exec rspec
+      run: ${{matrix.env}} bundle exec rake test


### PR DESCRIPTION
rspec actually discovers no tests here as they are defined in Rakefile. Using `rake test` instead works correctly.