### PR TITLE
Update motivation section in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,7 @@ strikethroughs, and autolinking.
 ## Motivation
 
 This code base was originally forked from [Commonmarker](https://github.com/gjtorikian/commonmarker) before they
-switched from `cmark-gfm` (C) to `comrak` (Rust). The original implementation provided access to the abstract syntax
-tree (AST), which is useful for building tools on top of Markdown. The Rust implementation does not provide this
-functionality, and so this fork was created to continue to provide these (and more) features.
+switched from `cmark-gfm` (C) to `comrak` (Rust). This fork was created to preserve the original C extension logic and provide alternate features.
 
 ## Usage
 


### PR DESCRIPTION
`commonmarker` has provided an AST for some time now, so I think it's fair to update this README. Not sure what additional features are provided here, but the Rust v C backing is probably the biggest difference.