### PR TITLE
Fix: Ensure end_line >= start_line for single-line blocks

### DIFF
--- a/ext/markly/blocks.c
+++ b/ext/markly/blocks.c
@@ -307,6 +307,10 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
       b->end_column -= 1;
   } else {
     b->end_line = parser->line_number - 1;
+    // Ensure end_line is at least start_line (fixes single-line HTML block bug)
+    if (b->end_line < b->start_line) {
+      b->end_line = b->start_line;
+    }
     b->end_column = parser->last_line_length;
   }
 

--- a/test/markly/node.rb
+++ b/test/markly/node.rb
@@ -270,4 +270,37 @@ describe Markly::Node do
 			expect(fragment.to_markdown).to be == "Hello `World`"
 		end
 	end
+
+	with "#source_position" do
+		it "has valid position for paragraphs" do
+			doc = Markly.parse("Hello\n\nWorld")
+			paragraph = doc.first_child
+			pos = paragraph.source_position
+
+			expect(pos[:start_line]).to be == 1
+			expect(pos[:end_line]).to be >= pos[:start_line]
+		end
+
+		it "has valid position for HTML comments (regression test)" do
+			# HTML blocks on a single line should have end_line >= start_line
+			# Previously, end_line could be less than start_line due to a bug
+			# in the finalize() function in blocks.c
+			doc = Markly.parse("Text\n\n<!-- HTML comment -->\n\nMore text")
+
+			doc.each do |node|
+				pos = node.source_position
+				expect(pos[:end_line]).to be >= pos[:start_line]
+			end
+		end
+
+		it "has correct position for single-line HTML block" do
+			doc = Markly.parse("<!-- comment -->")
+			html_node = doc.first_child
+			pos = html_node.source_position
+
+			expect(html_node.type).to be == :html
+			expect(pos[:start_line]).to be == 1
+			expect(pos[:end_line]).to be == 1
+		end
+	end
 end


### PR DESCRIPTION
## Summary

When parsing Markdown with HTML comments (or other single-line HTML blocks), the `source_position` returned by the node has `end_line < start_line`, which is an impossible/invalid range.

## Reproduction

```ruby
require "markly"

puts "Markly version: #{Markly::VERSION}"

test = <<~MD
Some text.

<!-- This is an HTML comment -->

More text.
MD

doc = Markly.parse(test)

doc.each do |node|
  pos = node.source_position
  puts "#{node.type}: lines #{pos[:start_line]}-#{pos[:end_line]}"
  
  if pos[:end_line] < pos[:start_line]
    puts "  ⚠️ BUG: end_line (#{pos[:end_line]}) < start_line (#{pos[:start_line]})"
  end
end
```

### Expected Output

```
paragraph: lines 1-1
html: lines 3-3       # end_line should equal start_line for single-line block
paragraph: lines 5-5
```

### Actual Output

```
Markly version: 0.15.1
paragraph: lines 1-1
html: lines 3-2
  ⚠️ BUG: end_line (2) < start_line (3)
paragraph: lines 5-5
```

## Root Cause

The bug is in `ext/markly/blocks.c` in the `finalize()` function around line 308:

```c
} else {
    b->end_line = parser->line_number - 1;
    b->end_column = parser->last_line_length;
}
```

For single-line HTML blocks (and potentially other block types), when the block is finalized on the following line, this calculates `end_line` as `parser->line_number - 1`. If the block started on line N and is finalized when the parser is on line N+1, then:
- `start_line` = N (set when block was created)
- `end_line` = (N+1) - 1 = N (this would be correct)

However, the issue occurs when the HTML block is immediately followed by a blank line. The parser moves to the blank line and finalizes the block there, but `parser->line_number - 1` doesn't account for the actual content span of the block.

The HTML comment on line 3 gets `start_line=3` when created, but by the time finalize is called, the parser state leads to `end_line=2`.

## Affected Node Types

This appears to affect at least:
- `:html` (HTML blocks/comments)
- Potentially other block types not explicitly handled in the `finalize()` switch

## Impact

- Any code that relies on `source_position` to extract source text will fail
- Range calculations like `start_line..end_line` become invalid
- Source mapping and error reporting becomes unreliable

## Suggested Fix

The `finalize()` function should ensure `end_line >= start_line` as a minimum bound:

```c
} else {
    b->end_line = parser->line_number - 1;
    // Ensure end_line is at least start_line
    if (b->end_line < b->start_line) {
        b->end_line = b->start_line;
    }
    b->end_column = parser->last_line_length;
}
```

Or alternatively, handle `CMARK_NODE_HTML_BLOCK` explicitly like other block types:

```c
} else if (S_type(b) == CMARK_NODE_HTML_BLOCK) {
    // HTML blocks need their actual end line preserved
    b->end_line = parser->line_number - 1;
    if (b->end_line < b->start_line) {
        b->end_line = b->start_line;
    }
    b->end_column = parser->last_line_length;
} else {
    // ...existing code...
}
```

## Environment

- Markly version: 0.15.1
- Ruby version: 4.0.0
- OS: Linux (Atomic Fedora / Bazzite)

Ref: Fixes #17 